### PR TITLE
Sync zsh fork to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # dotfiles
 
 ## Prerequisites
-### Packages
-* git
-* zsh
-* tmux
+
+* Install packages: `git` `zsh` `tmux`
+
 
 ## Usage
+
 ```shell script
 git clone --recurse-submodules https://github.com/chefdev/dotfiles.git .dotfiles
 ln -s .dotfiles/bash/.bashrc .bashrc # eventually make a copy first
@@ -15,7 +15,9 @@ ln -s .dotfiles/zsh/.p10k.zsh .p10k.zsh
 chsh -s $(which zsh)
 ```
 
+
 ## Keeping it up to date
+
 ```shell script
 git pull --recurse-submodules
 ```


### PR DESCRIPTION
Following submodules were updated to the latest version by using [this guide](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/syncing-a-fork):
- oh-my-zsh
- custom/plugins/zsh-syntax-highlighting
- custom/plugins/zsh-syntax-highlighting

